### PR TITLE
Resolve parameters via HTTP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+[Unreleased]: https://github.com/envato/stack_master-http_parameter_resolver/compare/v0.1.0...HEAD
+
+## [0.1.0] - 2020-01-14
+
+### Added
+
+- Initial functionality: Obtaining parameters from HTTP calls returning plain
+  text.
+
+[v0.1.0]: https://github.com/envato/stack_master-http_parameter_resolver/tree/v0.1.0

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![Build Status](https://travis-ci.org/envato/stack_master-http_parameter_resolver.svg?branch=master)](https://travis-ci.org/envato/stack_master-http_parameter_resolver)
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/stack_master/http_parameter_resolver`. To experiment with that code, run `script/console` for an interactive prompt.
+A [StackMaster] parameter resolver that obtains values via HTTP calls.
 
-TODO: Delete this and the text above, and describe your gem
+[StackMaster]: https://github.com/envato/stack_master
 
 ## Installation
 
@@ -24,7 +24,20 @@ Or install it yourself as:
 
 ## Usage
 
-TODO: Write usage instructions here
+For example, to resolve the Cloudflare IPv4 ranges:
+
+```yaml
+cloudflare_ips:
+  http: https://www.cloudflare.com/ips-v4
+```
+
+To obtain both the Cloudlare IPv4 and IPv6 ranges:
+
+```yaml
+cloudflare_ips:
+  - http: https://www.cloudflare.com/ips-v4
+  - http: https://www.cloudflare.com/ips-v6
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# StackMaster::GpgParameterResolver
+# StackMaster::HttpParameterResolver
 
 [![Build Status](https://travis-ci.org/envato/stack_master-http_parameter_resolver.svg?branch=master)](https://travis-ci.org/envato/stack_master-http_parameter_resolver)
 

--- a/lib/stack_master/http_parameter_resolver.rb
+++ b/lib/stack_master/http_parameter_resolver.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require 'stack_master'
+require 'stack_master/http_parameter_resolver/version'
+require 'stack_master/parameter_resolvers/http'

--- a/lib/stack_master/parameter_resolvers/http.rb
+++ b/lib/stack_master/parameter_resolvers/http.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'faraday'
+
+module StackMaster
+  module ParameterResolvers
+    class Http < Resolver
+      NotResolved = Class.new(StandardError)
+
+      array_resolver
+
+      def initialize(_config, _stack_definition); end
+
+      def resolve(url)
+        response = connection(url).get
+        response.body.split(/\s+/)
+      rescue Faraday::Error
+        raise NotResolved, "Unable to resolve HTTP parameters from #{url}"
+      end
+
+      private
+
+      def connection(url)
+        Faraday.new(
+          url: url,
+          params: {},
+          headers: { 'Accept' => 'text/plain' }
+        ) do |connection|
+          connection.response :raise_error
+          connection.adapter :net_http
+        end
+      end
+    end
+  end
+end

--- a/spec/stack_master/parameter_resolvers/http_spec.rb
+++ b/spec/stack_master/parameter_resolvers/http_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+RSpec.describe StackMaster::ParameterResolvers::Http do
+  subject(:http) { described_class.new(config, stack_definition) }
+  let(:config) { nil }
+  let(:stack_definition) { nil }
+
+  describe '#resolve' do
+    subject(:resolve) { http.resolve(url) }
+
+    let(:connection) { instance_spy(Faraday::Connection) }
+    before do
+      allow(Faraday).to receive(:new)
+        .with(url: url, params: anything, headers: anything)
+        .and_return(connection)
+    end
+
+    context 'given a URL https://www.cloudflare.com/ips-v4' do
+      let(:url) { 'https://www.cloudflare.com/ips-v4' }
+
+      context "and the HTTP servers returns:\n"\
+              "173.245.48.0/20\n"\
+              "103.21.244.0/22\n"\
+              '103.22.200.0/22' do
+        before { allow(connection).to receive(:get).and_return(response) }
+        let(:response) do
+          instance_spy(Faraday::Response, body: <<~BODY)
+            173.245.48.0/20
+            103.21.244.0/22
+            103.22.200.0/22
+          BODY
+        end
+
+        it { should eq(%w[173.245.48.0/20 103.21.244.0/22 103.22.200.0/22]) }
+      end
+
+      context 'and the HTTP servers returns 400 - not found' do
+        before { allow(connection).to receive(:get).and_raise(Faraday::ResourceNotFound, 404) }
+        specify { expect { resolve }.to raise_error(StackMaster::ParameterResolvers::Http::NotResolved) }
+      end
+    end
+  end
+end

--- a/stack_master-http_parameter_resolver.gemspec
+++ b/stack_master-http_parameter_resolver.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.4.0"
 
+  spec.add_dependency 'faraday', '~> 1'
   spec.add_dependency 'stack_master'
   spec.add_development_dependency 'bundler', '~> 2'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
Add initial functionality that can obtaining StackMaster parameters from HTTP calls returning plain text.

For example, to resolve the Cloudflare IPv4 ranges:

```yaml
cloudflare_ips:
  http: https://www.cloudflare.com/ips-v4
```

To obtain both the Cloudlare IPv4 and IPv6 ranges:

```yaml
cloudflare_ips:
  - http: https://www.cloudflare.com/ips-v4
  - http: https://www.cloudflare.com/ips-v6
```