### PR TITLE
Introduce strategies for parsing HTTP responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Introduce strategies for parsing the HTTP response ([#2]). This changes how
+  to configure the parameter resolver. eg.
+
+  ```diff
+   cloudflare_cidr_ips:
+  -  http: https://www.cloudflare.com/ips-v4
+  +  http:
+  +    url: https://www.cloudflare.com/ips-v4
+  +    strategy: one_per_line
+  ```
+
 [Unreleased]: https://github.com/envato/stack_master-http_parameter_resolver/compare/v0.1.0...HEAD
+[#2]: https://github.com/envato/stack_master-http_parameter_resolver/pull/2
 
 ## [0.1.0] - 2020-01-14
 

--- a/README.md
+++ b/README.md
@@ -18,11 +18,15 @@ gem 'stack_master-http_parameter_resolver'
 
 And then execute:
 
-    $ bundle
+```sh
+bundle install
+```
 
 Or install it yourself as:
 
-    $ gem install stack_master-http_parameter_resolver
+```sh
+gem install stack_master-http_parameter_resolver
+```
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # StackMaster::HttpParameterResolver
 
+[![License MIT](https://img.shields.io/badge/license-MIT-brightgreen.svg)](https://github.com/envato/stack_master-http_parameter_resolver/blob/master/LICENSE.txt)
+[![Gem Version](https://badge.fury.io/rb/stack_master-http_parameter_resolver.svg)](https://rubygems.org/gems/stack_master-http_parameter_resolver)
 [![Build Status](https://travis-ci.org/envato/stack_master-http_parameter_resolver.svg?branch=master)](https://travis-ci.org/envato/stack_master-http_parameter_resolver)
 
 A [StackMaster] parameter resolver that obtains values via HTTP calls.

--- a/README.md
+++ b/README.md
@@ -34,15 +34,21 @@ For example, to resolve the Cloudflare IPv4 ranges:
 
 ```yaml
 cloudflare_ips:
-  http: https://www.cloudflare.com/ips-v4
+  http:
+    url: https://www.cloudflare.com/ips-v4
+    strategy: one_per_line
 ```
 
 To obtain both the Cloudlare IPv4 and IPv6 ranges:
 
 ```yaml
 cloudflare_ips:
-  - http: https://www.cloudflare.com/ips-v4
-  - http: https://www.cloudflare.com/ips-v6
+  - http:
+      url: https://www.cloudflare.com/ips-v4
+      strategy: one_per_line
+  - http:
+      url: https://www.cloudflare.com/ips-v6
+      strategy: one_per_line
 ```
 
 ## Development

--- a/lib/stack_master/http_parameter_resolver/strategy/one_per_line.rb
+++ b/lib/stack_master/http_parameter_resolver/strategy/one_per_line.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module StackMaster
+  module HttpParameterResolver
+    module Strategy
+      class OnePerLine
+        def accept
+          'text/plain'
+        end
+
+        def parse(response)
+          response.body.split(/[\r\n]+/)
+        end
+      end
+    end
+  end
+end

--- a/lib/stack_master/parameter_resolvers/http.rb
+++ b/lib/stack_master/parameter_resolvers/http.rb
@@ -1,30 +1,66 @@
 # frozen_string_literal: true
 
+require 'active_support/core_ext/string/inflections'
 require 'faraday'
+
+Dir[File.join(__dir__, '..', 'http_parameter_resolver', 'strategy', '**', '*.rb')]
+  .sort.each { |file| require file }
 
 module StackMaster
   module ParameterResolvers
     class Http < Resolver
       NotResolved = Class.new(StandardError)
+      Misconfigured = Class.new(StandardError)
 
       array_resolver
 
       def initialize(_config, _stack_definition); end
 
-      def resolve(url)
-        response = connection(url).get
-        response.body.split(/\s+/)
+      def resolve(args)
+        usage unless args.is_a? Hash
+        url = args.fetch('url') { usage("'url' not provided") }
+        strategy = build_strategy(args.fetch('strategy') { usage("'strategy' not provided") })
+        http(url, strategy)
       rescue Faraday::Error
         raise NotResolved, "Unable to resolve HTTP parameters from #{url}"
       end
 
       private
 
-      def connection(url)
+      def usage(message = 'Misconfigured HTTP parameter resolver')
+        raise Misconfigured, <<~MESSAGE
+          #{message}
+
+          Please configure according to the following pattern:
+
+          <my-parameter-name>:
+            http:
+              url: <my-http-url>
+              strategy: <response-parsing-strategy>
+
+          Where <response-parsing-strategy> is one of the supported strategies:
+          - one_per_line
+        MESSAGE
+      end
+
+      def build_strategy(strategy)
+        class_name = "StackMaster::HttpParameterResolver::Strategy::"\
+                     "#{strategy.classify}"
+        class_name.constantize.new
+      rescue NameError
+        usage("The strategy #{strategy.inspect} is not supported")
+      end
+
+      def http(url, strategy)
+        response = connection(url, strategy).get
+        strategy.parse(response)
+      end
+
+      def connection(url, strategy)
         Faraday.new(
           url: url,
           params: {},
-          headers: { 'Accept' => 'text/plain' }
+          headers: { 'Accept' => strategy.accept }
         ) do |connection|
           connection.response :raise_error
           connection.adapter :net_http

--- a/spec/stack_master/parameter_resolvers/http_spec.rb
+++ b/spec/stack_master/parameter_resolvers/http_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe StackMaster::ParameterResolvers::Http do
   let(:stack_definition) { nil }
 
   describe '#resolve' do
-    subject(:resolve) { http.resolve(url) }
+    subject(:resolve) { http.resolve(args) }
 
     let(:connection) { instance_spy(Faraday::Connection) }
     before do
@@ -14,30 +14,57 @@ RSpec.describe StackMaster::ParameterResolvers::Http do
         .with(url: url, params: anything, headers: anything)
         .and_return(connection)
     end
+    let(:args) { {'url' => url, 'strategy' => strategy} }
+    let(:url) { nil }
 
-    context 'given a URL https://www.cloudflare.com/ips-v4' do
-      let(:url) { 'https://www.cloudflare.com/ips-v4' }
+    context 'given the strategy "one_per_line"' do
+      let(:strategy) { 'one_per_line' }
 
-      context "and the HTTP servers returns:\n"\
-              "173.245.48.0/20\n"\
-              "103.21.244.0/22\n"\
-              '103.22.200.0/22' do
-        before { allow(connection).to receive(:get).and_return(response) }
-        let(:response) do
-          instance_spy(Faraday::Response, body: <<~BODY)
-            173.245.48.0/20
-            103.21.244.0/22
-            103.22.200.0/22
-          BODY
+      context 'and a URL https://www.cloudflare.com/ips-v4' do
+        let(:url) { 'https://www.cloudflare.com/ips-v4' }
+
+        context "and the HTTP server returns:\n"\
+                "173.245.48.0/20\n"\
+                "103.21.244.0/22\n"\
+                '103.22.200.0/22' do
+          before { allow(connection).to receive(:get).and_return(response) }
+          let(:response) do
+            instance_spy(Faraday::Response, body: <<~BODY)
+              173.245.48.0/20
+              103.21.244.0/22
+              103.22.200.0/22
+            BODY
+          end
+
+          it { should eq(%w[173.245.48.0/20 103.21.244.0/22 103.22.200.0/22]) }
         end
 
-        it { should eq(%w[173.245.48.0/20 103.21.244.0/22 103.22.200.0/22]) }
+        context 'and the HTTP server returns 400 - not found' do
+          before { allow(connection).to receive(:get).and_raise(Faraday::ResourceNotFound, 404) }
+          specify { expect { resolve }.to raise_error(StackMaster::ParameterResolvers::Http::NotResolved) }
+        end
       end
+    end
 
-      context 'and the HTTP servers returns 400 - not found' do
-        before { allow(connection).to receive(:get).and_raise(Faraday::ResourceNotFound, 404) }
-        specify { expect { resolve }.to raise_error(StackMaster::ParameterResolvers::Http::NotResolved) }
-      end
+    context 'given the (non-existing) strategy "typo"' do
+      let(:strategy) { 'typo' }
+      let(:url) { 'https://www.cloudflare.com/ips-v4' }
+      specify { expect { resolve }.to raise_error(StackMaster::ParameterResolvers::Http::Misconfigured) }
+    end
+
+    context 'given a URL but no strategy' do
+      let(:args) { {'url' => 'https://www.cloudflare.com/ips-v4'} }
+      specify { expect { resolve }.to raise_error(StackMaster::ParameterResolvers::Http::Misconfigured) }
+    end
+
+    context 'given a strategy but no URL' do
+      let(:args) { {'strategy' => 'one_per_line'} }
+      specify { expect { resolve }.to raise_error(StackMaster::ParameterResolvers::Http::Misconfigured) }
+    end
+
+    context 'given a string' do
+      let(:args) { 'https://www.cloudflare.com/ips-v4' }
+      specify { expect { resolve }.to raise_error(StackMaster::ParameterResolvers::Http::Misconfigured) }
     end
   end
 end

--- a/stack_master-http_parameter_resolver.gemspec
+++ b/stack_master-http_parameter_resolver.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.4.0"
 
+  spec.add_dependency 'activesupport'
   spec.add_dependency 'faraday', '~> 1'
   spec.add_dependency 'stack_master'
   spec.add_development_dependency 'bundler', '~> 2'


### PR DESCRIPTION
In #1, @jacobbednarz identified that we were baking in a specific mechanism for parsing the HTTP response to obtain the parameters.

Refactor to a more extensible design by introducing response parsing strategies. This allows the gem to support multiple ways of parsing the response, and a convenient way to configure this HTTP parameter resolver in parameter YAML files.

```yaml
cloudflare_ips:
  http:
    url: https://www.cloudflare.com/ips-v4
    strategy: one_per_line
```