### PR TITLE
Run CI on GitHub actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+---
+name: tests
+on: [ push, pull_request ]
+jobs:
+  test:
+    name: Test (Ruby ${{ matrix.ruby }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby: [ '2.4', '2.5', '2.6', '2.7' ]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby ${{ matrix.ruby }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: RSpec
+        run: bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: ruby
-rvm:
-- 2.4
-- 2.5
-- 2.6
-- 2.7
-before_install:
-- gem update --system
-- gem install bundler -v '~> 2'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - Default git branch renamed to `main`.
+- CI build runs on GitHub Actions ([#3]).
 
 [Unreleased]: https://github.com/envato/stack_master-http_parameter_resolver/compare/v0.2.0...HEAD
+[#3]: https://github.com/envato/stack_master-http_parameter_resolver/pull/3
 
 ## [0.2.0] - 2020-05-25
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License MIT](https://img.shields.io/badge/license-MIT-brightgreen.svg)](https://github.com/envato/stack_master-http_parameter_resolver/blob/main/LICENSE.txt)
 [![Gem Version](https://badge.fury.io/rb/stack_master-http_parameter_resolver.svg)](https://rubygems.org/gems/stack_master-http_parameter_resolver)
-[![Build Status](https://travis-ci.org/envato/stack_master-http_parameter_resolver.svg?branch=main)](https://travis-ci.org/envato/stack_master-http_parameter_resolver)
+[![Build Status](https://github.com/envato/stack_master-http_parameter_resolver/workflows/tests/badge.svg?branch=main)](https://github.com/envato/stack_master-http_parameter_resolver/actions?query=branch%3Amain+workflow%3Atests)
 
 A [StackMaster] parameter resolver that obtains values via HTTP calls.
 


### PR DESCRIPTION
Migrate from Travis CI to [GitHub Actions](https://github.com/features/actions) for the CI build.